### PR TITLE
Fix missing extern keywords.

### DIFF
--- a/src/c/tga_reader.h
+++ b/src/c/tga_reader.h
@@ -30,8 +30,8 @@ typedef struct _TGA_ORDER {
 	int alphaShift;
 } TGA_ORDER;
 
-const TGA_ORDER *TGA_READER_ARGB;
-const TGA_ORDER *TGA_READER_ABGR;
+extern const TGA_ORDER *TGA_READER_ARGB;
+extern const TGA_ORDER *TGA_READER_ABGR;
 
 void *tgaMalloc(size_t size);
 void tgaFree(void *memory);


### PR DESCRIPTION
In header file we declares two pointers. As they are not in namespace/class/struct, we may have (and I had) issue with linking in my project. Declarations were present in two separate TU. Extern will fix it.